### PR TITLE
DASD-7322: Added Support to Send TEST and DEV ZenDesk Related Azure Metric Log Alerts to Specific Slack Channels

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -21,7 +21,13 @@
     "sharedStorageAccountConnectionString": {
       "type": "securestring"
     },
-    "slackWebhookUri": {
+    "slackWebhookUriDasAlerts": {
+      "type": "securestring"
+    },
+    "slackWebhookUriZenDeskDev": {
+      "type": "securestring"
+    },
+    "slackWebhookUriZenDeskLive": {
       "type": "securestring"
     },
     "logAnalyticsWorkspaceId": {
@@ -189,12 +195,28 @@
                 "value": "das-alerts"
               },
               {
+                "name": "SLACK_ZENDESKDEV_CHANNEL",
+                "value": "zendesk-dev"
+              },
+              {
+                "name": "SLACK_ZENDESKLIVE_CHANNEL",
+                "value": "zendesk-live"
+              },
+              {
                 "name": "SLACK_ICON_EMOJI",
                 "value": ":mega:"
               },
               {
-                "name": "SLACK_WEBHOOK_URI",
-                "value": "[parameters('slackWebhookUri')]"
+                "name": "SLACK_WEBHOOK_URI_DAS_ALERTS",
+                "value": "[parameters('slackWebhookUriDasAlerts')]"
+              },
+              {
+                "name": "SLACK_WEBHOOK_URI_ZENDESK_DEV",
+                "value": "[parameters('slackWebhookUriZenDeskDev')]"
+              },
+              {
+                "name": "SLACK_WEBHOOK_URI_ZENDESK_LIVE",
+                "value": "[parameters('slackWebhookUriZenDeskLive')]"
               },
               {
                 "name": "FUNCTIONS_WORKER_RUNTIME",

--- a/src/SFA.DAS.Monitoring.Functions/CommonAlertSchemaWebhook/Receive-Request.ps1
+++ b/src/SFA.DAS.Monitoring.Functions/CommonAlertSchemaWebhook/Receive-Request.ps1
@@ -14,14 +14,29 @@ try {
 
     $AlertData = $Request.Body.data
 
-    $Channel = $Configuration.Get("SLACK_DEFAULT_CHANNEL")
-    if ($Request.Query.Channel) {
-        $Channel = $Request.Query.Channel
-        Write-Information "Overriding SLACK_DEFAULT_CHANNEL with parameter $Channel"
+    switch -wildcard ($AlertData.essentials.alertRule){
+
+        "TEST - ZenDesk*" {
+            $Channel = $Configuration.Get("SLACK_ZENDESKDEV_CHANNEL")
+            Write-Information "Overriding SLACK_DEFAULT_CHANNEL with Slack channel $channel"
+            break
+        }
+
+        "PROD - ZenDesk*" {
+            $Channel = $Configuration.Get("SLACK_ZENDESKLIVE_CHANNEL")
+            Write-Information "Overriding SLACK_DEFAULT_CHANNEL with Slack channel $channel"
+            break
+        }
+
+        default {
+            $Channel = $Configuration.Get("SLACK_DEFAULT_CHANNEL")
+            break
+        }
+
     }
 
     $Message = New-Message -AlertData $AlertData -Channel $Channel
-    Send-SlackMessage -Message $Message
+    Send-SlackMessage -Message $Message -Channel $Channel
     Push-OutputBindingWrapper -StatusCode 202 -Body "Message accepted"
 
 }

--- a/src/SFA.DAS.Monitoring.Functions/Modules/FunctionHelpers/FunctionHelpers.psm1
+++ b/src/SFA.DAS.Monitoring.Functions/Modules/FunctionHelpers/FunctionHelpers.psm1
@@ -103,15 +103,34 @@ hashtable.  A hashtable representing the message to send to slack.
 
     Param(
         [Parameter(Mandatory = $true)]
-        [hashtable]$Message
+        [hashtable]$Message,
+        [Parameter(Mandatory = $true)]
+        [string] $Channel
     )
 
     try {
-
         Write-Information "Submitting slack message payload"
         $SerializedMessage = "payload=$($Message | ConvertTo-Json -Compress)"
         Write-Information $SerializedMessage
-        Invoke-WebRequest -Uri $Configuration.Get("SLACK_WEBHOOK_URI") -Method POST -UseBasicParsing -Body $SerializedMessage
+        switch ($Channel) {
+
+            "zendesk-dev" {
+                $SlackWebhookUri = $Configuration.Get("SLACK_WEBHOOK_URI_ZENDESK_DEV")
+                break
+            }
+
+            "zendesk-live" {
+                $SlackWebhookUri = $Configuration.Get("SLACK_WEBHOOK_URI_ZENDESK_LIVE")
+                break
+            }
+
+            default {
+                $SlackWebhookUri = $Configuration.Get("SLACK_WEBHOOK_URI_DAS_ALERTS")
+                break
+            }
+
+        }
+        Invoke-WebRequest -Uri $SlackWebhookUri -Method POST -UseBasicParsing -Body $SerializedMessage
     }
     catch {
         $ErrorResponse = $_.Exception.Message


### PR DESCRIPTION
- Now that das-platform-monitoring-jobs supports failure related metric alerts (See merged PR https://github.com/SkillsFundingAgency/das-platform-monitoring-jobs/pull/6) this PR is to allow specific alerts starting either `TEST - ZenDesk*` or `PROD - ZenDesk*` to be sent to specific Slack channels. This has been requested as das-alerts Slack channel can become noisy and alerts lost due to ZenDesk team not regularly checking the das-alerts channel. `TEST - ZenDesk*` alerts will go to #zendesk-dev and `PROD - ZenDesk*` will go to #zendesk-live
- The ARM template `azure/template.json` has been updated to include the additional required Slack incoming webhooks. The app config settings for the monitoring function app now includes the names of the slack channels so that it can be called from configuration.
- The script `src/SFA.DAS.Monitoring.Functions/CommonAlertSchemaWebhook/Receive-Request.ps1` has been updated to check the `alertRule` name to check if an alert meets the criteria so that the channel name can be overridden from the default `das-alerts`.
- The function `Send-SlackMessage` in module `src/SFA.DAS.Monitoring.Functions/Modules/FunctionHelpers/FunctionHelpers.psm1` has been updated to check which channel the message needs to be sent to, depending on the new channel parameter use the appropriate Slack incoming webhook. The default is to use das-alerts.