### PR TITLE
Removed metricAlertsArray parameter example and renamed parameter to areMetricAlertsEnabled

### DIFF
--- a/azure/metric-alerts.json
+++ b/azure/metric-alerts.json
@@ -8,7 +8,7 @@
         "description": "The array of metric alert objects."
       }
     },
-    "isMetricAlertEnabled": {
+    "areMetricAlertsEnabled": {
       "type": "bool",
       "metadata": {
         "description": "Specifies whether the alert is enabled."
@@ -47,7 +47,7 @@
             "value": 0
           },
           "isEnabled": {
-            "value": "[parameters('IsMetricAlertEnabled')]"
+            "value": "[parameters('areMetricAlertsEnabled')]"
           },
           "targetResourceType": {
             "value": "microsoft.insights/components"

--- a/azure/metric-alerts.json
+++ b/azure/metric-alerts.json
@@ -5,19 +5,7 @@
     "metricAlertsArray": {
       "type": "array",
       "metadata": {
-        "description": "The array of metric alert objects. E.g.
-        [
-            {
-                \"appInsightsResourceGroup\": \"das-pp-foo-rg\",
-                \"appInsightsName\": \"das-pp-foo-fa\",
-                \"metricName\": \"dependencies/failed\",
-                \"metricOperator\": \"GreaterThan\",
-                \"metricThreshold\": 0,
-                \"timeAggregation\": \"Count\",
-                \"windowSize\": \"P1D\",
-                \"evaluationFrequency\": \"PT1H\"
-            }
-        ]"
+        "description": "The array of metric alert objects."
       }
     },
     "isMetricAlertEnabled": {


### PR DESCRIPTION
ARM template deployment task fails with Unexpected token so removing metricAlertsArray parameter example with quotation marks. Re-add after ARM template deployment task is fixed.

Renamed parameter to areMetricAlertsEnabled