### PR TITLE
Dasd 8884 edit metric alert rule name

### DIFF
--- a/azure/metric-alerts.json
+++ b/azure/metric-alerts.json
@@ -38,7 +38,7 @@
         },
         "parameters": {
           "alertName": {
-            "value": "[replace(concat(parameters('metricAlertsArray')[copyIndex()].appInsightsName, ' - ', parameters('metricAlertsArray')[copyIndex()].metricName, ' ', parameters('metricAlertsArray').metricOperator, ' ', parameters('metricAlertsArray').metricThreshold), '/', '-')]"
+            "value": "[replace(concat(parameters('metricAlertsArray')[copyIndex()].appInsightsName, ' - ', parameters('metricAlertsArray')[copyIndex()].metricName, ' ', parameters('metricAlertsArray')[copyIndex()].metricOperator, ' ', parameters('metricAlertsArray')[copyIndex()].metricThreshold), '/', '-')]"
           },
           "alertDescription": {
             "value": "[concat(parameters('metricAlertsArray')[copyIndex()].metricName, ' ', parameters('metricAlertsArray')[copyIndex()].metricOperator, ' ', parameters('metricAlertsArray')[copyIndex()].metricThreshold)]"

--- a/azure/metric-alerts.json
+++ b/azure/metric-alerts.json
@@ -27,7 +27,7 @@
   "resources": [
     {
       "apiVersion": "2020-10-01",
-      "name": "[concat('metric-alerts-', parameters('metricAlertsArray')[copyIndex()].appInsightsName)]",
+      "name": "[replace(concat('metric-alerts-', parameters('metricAlertsArray')[copyIndex()].appInsightsName, '-', parameters('metricAlertsArray')[copyIndex()].metricOperator, '-', parameters('metricAlertsArray')[copyIndex()].metricThreshold), '/', '-')]",
       "resourceGroup": "[parameters('metricAlertsArray')[copyIndex()].appInsightsResourceGroup]",
       "type": "Microsoft.Resources/deployments",
       "properties": {

--- a/azure/metric-alerts.json
+++ b/azure/metric-alerts.json
@@ -38,7 +38,7 @@
         },
         "parameters": {
           "alertName": {
-            "value": "[replace(concat(parameters('metricAlertsArray')[copyIndex()].appInsightsName, ' - ', parameters('metricAlertsArray')[copyIndex()].metricName), '/', '-')]"
+            "value": "[replace(concat(parameters('metricAlertsArray')[copyIndex()].appInsightsName, ' - ', parameters('metricAlertsArray')[copyIndex()].metricName, ' ', parameters('metricAlertsArray').metricOperator, ' ', parameters('metricAlertsArray').metricThreshold), '/', '-')]"
           },
           "alertDescription": {
             "value": "[concat(parameters('metricAlertsArray')[copyIndex()].metricName, ' ', parameters('metricAlertsArray')[copyIndex()].metricOperator, ' ', parameters('metricAlertsArray')[copyIndex()].metricThreshold)]"


### PR DESCRIPTION
Edited metric alert rule name to be unique when alert rules are for same app Insights resource, metricNamespace, metricName but different metricOperator

Needed as metricOperator NotEquals does not currently work, Azure Support are aware
https://docs.microsoft.com/en-us/azure/templates/microsoft.insights/2018-03-01/metricalerts?tabs=json#singleresourcemultiplemetriccriteria-object